### PR TITLE
Add base formula for lib-odb connectors. Add all connectors

### DIFF
--- a/libodb-base.rb
+++ b/libodb-base.rb
@@ -1,0 +1,61 @@
+class LibodbBase < Formula
+  url "http://www.codesynthesis.com/download/odb/2.4/libodb-2.4.0.tar.gz.sha1"
+  sha256 "2d26995974eb03b6ba6d26c32f9956e95d5a3d0db6b5fa149a2df7e4773112f4"
+  homepage "http://www.codesynthesis.com/products/odb/"
+
+  option "with-libstdc++",
+         "Force compiling with libstdc++ (Default BEFORE 10.9)"
+  option "with-libc++",
+         "Force compiling with libc++ (Default SINCE 10.9)"
+  option "with-gcc",
+         "Force compiling with gcc and GCC's libstdc++"
+
+  if build.with?("gcc")
+    depends_on "gcc"
+
+    fails_with :clang
+    fails_with :llvm
+
+    STDLIB = "gcc"
+  elsif build.with?("libstdc++")
+    STDLIB = "libstdc++"
+  elsif build.with?("libc++")
+    STDLIB = "libc++"
+  else
+    STDLIB = MacOS.version < :mavericks ? "libstdc++" : "libc++"
+  end
+
+  depends_on "libodb" => "with-" + STDLIB
+
+  def standard_install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+    ]
+
+    if STDLIB != "gcc"
+      args << "CXX=#{ENV.cxx}\ -stdlib=#{STDLIB}"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+
+    opoo <<-EOS.undent
+      Your app, libodb and its libs must be compiled with the same
+      C++ standard library. Currently: #{STDLIB}
+    EOS
+  end
+
+  def install
+    onoe <<-EOS.undent
+      Do not install this formula. Instead, install the formula for the database
+      you wish to use.
+    EOS
+    exit 1
+  end
+
+  test do
+    raise
+  end
+
+end

--- a/libodb-mssql.rb
+++ b/libodb-mssql.rb
@@ -1,0 +1,24 @@
+require_relative "libodb-base"
+class LibodbMssql < LibodbBase
+  url "http://www.codesynthesis.com/download/odb/2.4/libodb-mssql-2.4.0.tar.gz"
+  sha256 "7863ce814c144cbd464709018007918c19ba71760e484022faa2fa5bf40bdfe7"
+
+  def install
+    standard_install
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <odb/mssql/exceptions.hxx>
+      int main()
+      {
+        try {
+          throw odb::mssql::database_exception();
+        } catch (const odb::mssql::database_exception &e) {}
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "test", "-lodb-mssql", "-lodb"
+    system "./test"
+  end
+end

--- a/libodb-mysql.rb
+++ b/libodb-mysql.rb
@@ -1,0 +1,26 @@
+require_relative "libodb-base"
+class LibodbMysql < LibodbBase
+  url "http://www.codesynthesis.com/download/odb/2.4/libodb-mysql-2.4.0.tar.gz"
+  sha256 "95e5b7a4ef3cc5abbb91e7f155b6b74d5e143df99258da1d49097bb7498eefef"
+
+  depends_on "mysql-connector-c"
+
+  def install
+    standard_install
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <odb/mysql/exceptions.hxx>
+      int main()
+      {
+        try {
+          throw odb::mysql::database_exception(0, "state", "message");
+        } catch (const odb::mysql::database_exception &e) {}
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "test", "-lodb-mysql", "-lodb"
+    system "./test"
+  end
+end

--- a/libodb-oracle.rb
+++ b/libodb-oracle.rb
@@ -1,0 +1,24 @@
+require_relative "libodb-base"
+class LibodbOracle < LibodbBase
+  url "http://www.codesynthesis.com/download/odb/2.4/libodb-oracle-2.4.0.tar.gz"
+  sha256 "57b4d5da5efc262e7fdecd764565fb8e25168838b09604f6815cd3c1c237aa06"
+
+  def install
+    standard_install
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <odb/oracle/exceptions.hxx>
+      int main()
+      {
+        try {
+          throw odb::oracle::database_exception("test exception");
+        } catch (const odb::oracle::database_exception &e) {}
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "test", "-lodb-oracle", "-lodb"
+    system "./test"
+  end
+end

--- a/libodb-pgsql.rb
+++ b/libodb-pgsql.rb
@@ -1,0 +1,24 @@
+require_relative "libodb-base"
+class LibodbPgsql < LibodbBase
+  url "http://www.codesynthesis.com/download/odb/2.4/libodb-pgsql-2.4.0.tar.gz"
+  sha256 "8e365b33617ec8ad8594d488755659dea28eea6463eedcde2ec59655fef20f1d"
+
+  def install
+    standard_install
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <odb/pgsql/exceptions.hxx>
+      int main()
+      {
+        try {
+          throw odb::pgsql::database_exception("test exception");
+        } catch (const odb::pgsql::database_exception &e) {}
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "test", "-lodb-pgsql", "-lodb"
+    system "./test"
+  end
+end

--- a/libodb-sqlite.rb
+++ b/libodb-sqlite.rb
@@ -1,31 +1,7 @@
-class LibodbSqlite < Formula
-  homepage "http://www.codesynthesis.com/products/odb/"
+require_relative "libodb-base"
+class LibodbSqlite < LibodbBase
   url "http://www.codesynthesis.com/download/odb/2.4/libodb-sqlite-2.4.0.tar.gz"
   sha256 "cd687c882a8dc14ded4eb160e82de57e476b1feef5c559c5a6a5c7e671a10cf4"
-
-  option "with-libstdc++",
-         "Force compiling with libstdc++ (Default BEFORE 10.9)"
-  option "with-libc++",
-         "Force compiling with libc++ (Default SINCE 10.9)"
-  option "with-gcc",
-         "Force compiling with gcc and GCC's libstdc++"
-
-  if build.with?("gcc")
-    depends_on "gcc"
-
-    fails_with :clang
-    fails_with :llvm
-
-    STDLIB = "gcc"
-  elsif build.with?("libstdc++")
-    STDLIB = "libstdc++"
-  elsif build.with?("libc++")
-    STDLIB = "libc++"
-  else
-    STDLIB = MacOS.version < :mavericks ? "libstdc++" : "libc++"
-  end
-
-  depends_on "libodb" => "with-" + STDLIB
 
   patch do
     url "http://scm.codesynthesis.com/?p=odb/libodb-sqlite.git;a=patch;h=27a578709046a81bb0efc0027bfc74318615447e"
@@ -33,22 +9,7 @@ class LibodbSqlite < Formula
   end
 
   def install
-    args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-    ]
-
-    if STDLIB != "gcc"
-      args << "CXX=#{ENV.cxx}\ -stdlib=#{STDLIB}"
-    end
-
-    system "./configure", *args
-    system "make", "install"
-
-    opoo <<-EOS.undent
-      Your app, libodb and its libs must be compiled with the same
-      C++ standard library. Currently: #{STDLIB}
-    EOS
+    standard_install
   end
 
   test do


### PR DESCRIPTION
They all install appropriately, with the following caveats:
- I've only tested the postgres formula thoroughly (because that's the one I'm using)
- The oracle connector requires oracle-specific libraries that don't currently have formulae and so need to be installed separately.

Thanks!
