### PR TITLE
Move dependencies back to connector scripts

### DIFF
--- a/libodb-base.rb
+++ b/libodb-base.rb
@@ -27,14 +27,14 @@ class LibodbBase < Formula
 
   depends_on "libodb" => "with-" + STDLIB
 
-  def standard_install
+  def standard_install(stdlib)
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
     ]
 
-    if STDLIB != "gcc"
-      args << "CXX=#{ENV.cxx}\ -stdlib=#{STDLIB}"
+    if stdlib != "gcc"
+      args << "CXX=#{ENV.cxx}\ -stdlib=#{stdlib}"
     end
 
     system "./configure", *args
@@ -42,7 +42,7 @@ class LibodbBase < Formula
 
     opoo <<-EOS.undent
       Your app, libodb and its libs must be compiled with the same
-      C++ standard library. Currently: #{STDLIB}
+      C++ standard library. Currently: #{stdlib}
     EOS
   end
 

--- a/libodb-mssql.rb
+++ b/libodb-mssql.rb
@@ -1,17 +1,36 @@
 require_relative "libodb-base"
 class LibodbMssql < LibodbBase
+  homepage "http://www.codesynthesis.com/products/odb/"
   url "http://www.codesynthesis.com/download/odb/2.4/libodb-mssql-2.4.0.tar.gz"
   sha256 "7863ce814c144cbd464709018007918c19ba71760e484022faa2fa5bf40bdfe7"
 
   option "with-libstdc++",
-           "Force compiling with libstdc++ (Default BEFORE 10.9)"
+         "Force compiling with libstdc++ (Default BEFORE 10.9)"
   option "with-libc++",
          "Force compiling with libc++ (Default SINCE 10.9)"
   option "with-gcc",
          "Force compiling with gcc and GCC's libstdc++"
 
+  if build.with?("gcc")
+    depends_on "gcc"
+
+    fails_with :clang
+    fails_with :llvm
+
+    STDLIB = "gcc"
+  elsif build.with?("libstdc++")
+    STDLIB = "libstdc++"
+  elsif build.with?("libc++")
+    STDLIB = "libc++"
+  else
+    STDLIB = MacOS.version < :mavericks ? "libstdc++" : "libc++"
+  end
+
+  depends_on "libodb" => "with-" + STDLIB
+  depends_on "libiodbc"
+
   def install
-    standard_install
+    standard_install(STDLIB)
   end
 
   test do

--- a/libodb-mysql.rb
+++ b/libodb-mysql.rb
@@ -1,19 +1,36 @@
 require_relative "libodb-base"
 class LibodbMysql < LibodbBase
+  homepage "http://www.codesynthesis.com/products/odb/"
   url "http://www.codesynthesis.com/download/odb/2.4/libodb-mysql-2.4.0.tar.gz"
   sha256 "95e5b7a4ef3cc5abbb91e7f155b6b74d5e143df99258da1d49097bb7498eefef"
 
-  depends_on "mysql-connector-c"
-
   option "with-libstdc++",
-           "Force compiling with libstdc++ (Default BEFORE 10.9)"
+         "Force compiling with libstdc++ (Default BEFORE 10.9)"
   option "with-libc++",
          "Force compiling with libc++ (Default SINCE 10.9)"
   option "with-gcc",
          "Force compiling with gcc and GCC's libstdc++"
 
+  if build.with?("gcc")
+    depends_on "gcc"
+
+    fails_with :clang
+    fails_with :llvm
+
+    STDLIB = "gcc"
+  elsif build.with?("libstdc++")
+    STDLIB = "libstdc++"
+  elsif build.with?("libc++")
+    STDLIB = "libc++"
+  else
+    STDLIB = MacOS.version < :mavericks ? "libstdc++" : "libc++"
+  end
+
+  depends_on "libodb" => "with-" + STDLIB
+  depends_on "mysql-connector-c"
+
   def install
-    standard_install
+    standard_install(STDLIB)
   end
 
   test do

--- a/libodb-oracle.rb
+++ b/libodb-oracle.rb
@@ -1,17 +1,35 @@
 require_relative "libodb-base"
 class LibodbOracle < LibodbBase
+  homepage "http://www.codesynthesis.com/products/odb/"
   url "http://www.codesynthesis.com/download/odb/2.4/libodb-oracle-2.4.0.tar.gz"
   sha256 "57b4d5da5efc262e7fdecd764565fb8e25168838b09604f6815cd3c1c237aa06"
 
   option "with-libstdc++",
-           "Force compiling with libstdc++ (Default BEFORE 10.9)"
+         "Force compiling with libstdc++ (Default BEFORE 10.9)"
   option "with-libc++",
          "Force compiling with libc++ (Default SINCE 10.9)"
   option "with-gcc",
          "Force compiling with gcc and GCC's libstdc++"
 
+  if build.with?("gcc")
+    depends_on "gcc"
+
+    fails_with :clang
+    fails_with :llvm
+
+    STDLIB = "gcc"
+  elsif build.with?("libstdc++")
+    STDLIB = "libstdc++"
+  elsif build.with?("libc++")
+    STDLIB = "libc++"
+  else
+    STDLIB = MacOS.version < :mavericks ? "libstdc++" : "libc++"
+  end
+
+  depends_on "libodb" => "with-" + STDLIB
+
   def install
-    standard_install
+    standard_install(STDLIB)
   end
 
   test do

--- a/libodb-pgsql.rb
+++ b/libodb-pgsql.rb
@@ -1,17 +1,35 @@
 require_relative "libodb-base"
 class LibodbPgsql < LibodbBase
+  homepage "http://www.codesynthesis.com/products/odb/"
   url "http://www.codesynthesis.com/download/odb/2.4/libodb-pgsql-2.4.0.tar.gz"
   sha256 "8e365b33617ec8ad8594d488755659dea28eea6463eedcde2ec59655fef20f1d"
 
   option "with-libstdc++",
-           "Force compiling with libstdc++ (Default BEFORE 10.9)"
+         "Force compiling with libstdc++ (Default BEFORE 10.9)"
   option "with-libc++",
          "Force compiling with libc++ (Default SINCE 10.9)"
   option "with-gcc",
          "Force compiling with gcc and GCC's libstdc++"
 
+  if build.with?("gcc")
+    depends_on "gcc"
+
+    fails_with :clang
+    fails_with :llvm
+
+    STDLIB = "gcc"
+  elsif build.with?("libstdc++")
+    STDLIB = "libstdc++"
+  elsif build.with?("libc++")
+    STDLIB = "libc++"
+  else
+    STDLIB = MacOS.version < :mavericks ? "libstdc++" : "libc++"
+  end
+
+  depends_on "libodb" => "with-" + STDLIB
+
   def install
-    standard_install
+    standard_install(STDLIB)
   end
 
   test do

--- a/libodb-sqlite.rb
+++ b/libodb-sqlite.rb
@@ -1,22 +1,40 @@
 require_relative "libodb-base"
 class LibodbSqlite < LibodbBase
+  homepage "http://www.codesynthesis.com/products/odb/"
   url "http://www.codesynthesis.com/download/odb/2.4/libodb-sqlite-2.4.0.tar.gz"
   sha256 "cd687c882a8dc14ded4eb160e82de57e476b1feef5c559c5a6a5c7e671a10cf4"
+
+  option "with-libstdc++",
+         "Force compiling with libstdc++ (Default BEFORE 10.9)"
+  option "with-libc++",
+         "Force compiling with libc++ (Default SINCE 10.9)"
+  option "with-gcc",
+         "Force compiling with gcc and GCC's libstdc++"
+
+  if build.with?("gcc")
+    depends_on "gcc"
+
+    fails_with :clang
+    fails_with :llvm
+
+    STDLIB = "gcc"
+  elsif build.with?("libstdc++")
+    STDLIB = "libstdc++"
+  elsif build.with?("libc++")
+    STDLIB = "libc++"
+  else
+    STDLIB = MacOS.version < :mavericks ? "libstdc++" : "libc++"
+  end
+
+  depends_on "libodb" => "with-" + STDLIB
 
   patch do
     url "http://scm.codesynthesis.com/?p=odb/libodb-sqlite.git;a=patch;h=27a578709046a81bb0efc0027bfc74318615447e"
     sha256 "daa40de58d78efc1d9b65e2cc767c4e72a26ceb8a8b8fde5e2d8e2d310a9a535"
   end
 
-  option "with-libstdc++",
-           "Force compiling with libstdc++ (Default BEFORE 10.9)"
-  option "with-libc++",
-         "Force compiling with libc++ (Default SINCE 10.9)"
-  option "with-gcc",
-         "Force compiling with gcc and GCC's libstdc++"
-
   def install
-    standard_install
+    standard_install(STDLIB)
   end
 
   test do


### PR DESCRIPTION
homebrew does not respect dependencies declared in base classes, so all the code must be duplicated in each connector.

I tested this by doing:

```
brew uninstall libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle
brew install libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle
brew uninstall libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle
brew install libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle --with-gcc
brew uninstall libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle
brew install libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle --with-libc++
brew uninstall libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle
brew install libodb libodb-sqlite libodb-mssql libodb-pgsql libodb-mysql libodb-oracle --with-libstdc++
```
